### PR TITLE
Added support for blog.cover for template's header image

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -4,7 +4,7 @@
     the {body} of the default.hbs template, which contains our header/footer. }}
 
 {{! The big featured header on the homepage, with the site logo and description }}
-<header  class="top-header top-header-bg">
+<header  class="top-header top-header-bg" {{#if @blog.cover}}style="background-image: url({{@blog.cover}})"{{/if}}>
 {{> header-image}}
   <div class="grid-container height-100">
     <div class="grid-100 mobile-grid-100 header height-100">


### PR DESCRIPTION
In a related matter I'm not sure what the header-image partial is for.

An alternative/improved configuration would be using an absolutely positioned image within the header that has a width of 100%. This tends to work better on mobile devices since background image attributes can be buggy on ios. You just have to keep your z-index's straight. 
