### PR TITLE
change word-break to word-wrap to prevent broken words

### DIFF
--- a/assets/stylesheets/style.css
+++ b/assets/stylesheets/style.css
@@ -564,9 +564,7 @@ body .post {
   font-family: 'Source Sans Pro', sans-serif;
   color: #333332;
   border-bottom: 1px solid #f2f2f0;
-  -ms-word-break: break-all;
-  word-break: break-all;
-  word-break: break-word;
+  word-wrap: break-word;
 }
 /* line 208, ../sass/partials/_page.scss */
 body .post hr {


### PR DESCRIPTION
We ran into some trouble on Firefox and IE, where words were broken off abruptly: 

![word breaks on ff and ie](https://cloud.githubusercontent.com/assets/4135610/2675319/d7a626e0-c115-11e3-9393-069f3294fd2c.png)

Chrome did fine though - because it only accepts the second one of these two properties:

``` css
word-break: break-all;
word-break: break-word;
```

[So it seems like the results of that Compass mixin are different across browsers.](http://compass-style.org/reference/compass/css3/hyphenation/#mixin-word-break)

Changing to `word-wrap: break-word;` solved the problem on FF, and Chrome is still doing fine. Will test on IE9+ tomorrow (since IE8 gives a .js error + always shows the post in _mobile_ width, I assume it's not supported).
